### PR TITLE
add draw optimization flag

### DIFF
--- a/expose.user.js
+++ b/expose.user.js
@@ -54,7 +54,7 @@ var allRules = [
               m.replace("var:disableRendering:2 hook:skipCellDraw",
                         /(\w+:function\(\w+\){)(if\(this\.\w+\(\)\){\+\+this\.[\w$]+;)/,
                         "$1" + "if($v || $H(this))return;" + "$2") &&
-            m.replace("var:optimizeCellDraw",
+            m.replace("var:simpleCellDraw",
                        /(if\()(\w+\)\w+\.beginPath\(\))/,
                         "$1$v||$2",
                         "$v=false") &&

--- a/expose.user.js
+++ b/expose.user.js
@@ -54,6 +54,10 @@ var allRules = [
               m.replace("var:disableRendering:2 hook:skipCellDraw",
                         /(\w+:function\(\w+\){)(if\(this\.\w+\(\)\){\+\+this\.[\w$]+;)/,
                         "$1" + "if($v || $H(this))return;" + "$2") &&
+            m.replace("var:optimizeCellDraw",
+                       /(if\()(\w+\)\w+\.beginPath\(\))/,
+                        "$1$v||$2",
+                        "$v=false") &&
               m.replace("var:rawViewport:scale",
                         /Math\.pow\(Math\.min\(64\/\w+,1\),\.4\)/,
                         "($v.scale=$&)") &&


### PR DESCRIPTION
Setting window.agar.optimizeCellDraw to _true_ will make all the cells, viruses, food and pellets render via arc() instead of lineTo(), thus disabling spikes for viruses and squiggly borders for everything else.
![optimization](https://cloud.githubusercontent.com/assets/13553882/12074972/943dc22e-b181-11e5-86da-4125310e4013.png)
